### PR TITLE
correctly parse read_timeout and write_timeout values that are specified in URLs

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -40,13 +40,13 @@ func (t TimeoutDriver) Open(connection string) (_ driver.Conn, err error) {
 	for _, setting := range strings.Fields(connection) {
 		s := strings.Split(setting, "=")
 		if s[0] == "read_timeout" {
-			val, err := strconv.Atoi(s[1])
+			val, err := strconv.Atoi(stripQuotes(s[1]))
 			if err != nil {
 				return nil, fmt.Errorf("Error interpreting value for read_timeout")
 			}
 			readTimeout = time.Duration(val) * time.Millisecond // timeout is in milliseconds
 		} else if s[0] == "write_timeout" {
-			val, err := strconv.Atoi(s[1])
+			val, err := strconv.Atoi(stripQuotes(s[1]))
 			if err != nil {
 				return nil, fmt.Errorf("Error interpreting value for write_timeout")
 			}
@@ -65,4 +65,11 @@ func (t TimeoutDriver) Open(connection string) (_ driver.Conn, err error) {
 			readTimeout:    readTimeout,
 			writeTimeout:   writeTimeout},
 		newConnectionStr)
+}
+
+func stripQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -175,7 +175,7 @@ func TestPostgresURL(t *testing.T) {
 		t.Error("Unexpected error")
 	}
 
-	if connection != "dbname=pqtest host=localhost password=password sslmode=verify-full user=pqtest" {
+	if connection != "dbname='pqtest' host='localhost' password='password' sslmode='verify-full' user='pqtest'" {
 		t.Errorf("The connection string was not as expected: %q", connection)
 	}
 
@@ -209,7 +209,7 @@ func TestPostgresqlURLError(t *testing.T) {
 		t.Error("An error was expected")
 	}
 
-	if err.Error() != "parse postgresql://pqtest\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100: invalid character \"\\\\\" in host name" {
+	if err.Error() != "parse \"postgresql://pqtest\\\\\\\\/:password@localhost/pqtest?read_timeout=500&sslmode=verify-full&write_timeout=100\": invalid character \"\\\\\" in host name" {
 		t.Errorf("The error was not as expected: %q", err.Error())
 	}
 


### PR DESCRIPTION
Specifying a timeout in a URL ends up generating a connection string that looks like

```
pplication_name='wf-actions-server' binary_parameters='no' connect_timeout='10' dbname='integrationcustomconnectionsstaging' host='integration-custom-connections-db.postgres.us1.staging.dog' password='password' port='5433' read_timeout='1000' sslmode='require' user='wfapp' write_timeout='500'
```

To parse the read/write timeouts correctly we need to strip the leading and trailing quotes from the timeout values.